### PR TITLE
ci: add GitHub Actions workflow with coverage

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,1 @@
+-P ubuntu-latest=rust:1-bookworm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,91 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run tests
+        run: cargo test --all-features
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install clippy
+        run: rustup component add clippy
+
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install rustfmt
+        run: rustup component add rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build
+        run: cargo build --all-features
+
+  coverage:
+    name: Code Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust nightly
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: llvm-tools-preview
+
+      - name: Install grcov
+        run: cargo install grcov
+
+      - name: Run tests with coverage
+        env:
+          RUSTFLAGS: "-C instrument-coverage"
+          LLVM_PROFILE_FILE: "target/coverage/profraw/xtask-%p-%m.profraw"
+        run: cargo test --all-features
+
+      - name: Generate coverage report
+        run: |
+          grcov target/coverage/profraw \
+            --binary-path target/debug \
+            --source-dir . \
+            --output-type lcov \
+            --ignore "/*" \
+            --ignore "*/tests/*" \
+            --output-path target/coverage/lcov.info
+
+      # Skip upload when running locally with act (GitHub Actions local testing tool)
+      - name: Upload to codecov
+        if: ${{ !env.ACT }}
+        uses: codecov/codecov-action@v4
+        with:
+          files: target/coverage/lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Add CI workflow with:
- Test: run all tests
- Clippy: lint with warnings as errors
- Format: check code formatting
- Build: verify project builds
- Coverage: generate coverage with grcov and upload to codecov

Add .actrc to configure local testing with act using Rust docker image. Coverage upload skipped when running locally with act.