### PR TITLE
Improve version bump command

### DIFF
--- a/src/commands/bump_version.rs
+++ b/src/commands/bump_version.rs
@@ -170,7 +170,11 @@ pub fn bump_version(level: &BumpLevel, current: &Version) -> Result<Version> {
                     if let Ok(next_pre) = semver::Prerelease::new(&format!("{prefix}.{next}")) {
                         new_version.pre = next_pre;
                     }
+                } else {
+                    return Err(anyhow!("unexpected prerelease format: {}", current.pre));
                 }
+            } else {
+                return Err(anyhow!("unexpected prerelease format: {}", current.pre));
             }
         }
         BumpLevel::PromotePreRelease => {
@@ -278,6 +282,20 @@ mod tests {
             )
             .unwrap(),
             Version::parse("1.2.3-rc.1").unwrap()
+        );
+
+        assert_eq!(
+            bump_version(&BumpLevel::PreRelease, &Version::parse("1.2.3-alpha123").unwrap())
+                .unwrap_err()
+                .to_string(),
+            "unexpected prerelease format: alpha123",
+        );
+
+        assert_eq!(
+            bump_version(&BumpLevel::PreRelease, &Version::parse("1.2.3-alpha.custom").unwrap())
+                .unwrap_err()
+                .to_string(),
+            "unexpected prerelease format: alpha.custom",
         );
     }
 

--- a/src/commands/bump_version.rs
+++ b/src/commands/bump_version.rs
@@ -34,7 +34,7 @@ pub fn run(args: CommandArgs) -> Result<()> {
     let current_version = Version::parse(&current_version_str)?;
 
     // bump the version
-    let new_version = bump_version(&args.level, &current_version);
+    let new_version = bump_version(&args.level, &current_version)?;
 
     // get all crates
     let all_crates = crate::common::get_all_crates().context("failed to get all crates")?;
@@ -140,7 +140,7 @@ pub fn run(args: CommandArgs) -> Result<()> {
     Ok(())
 }
 
-pub fn bump_version(level: &BumpLevel, current: &Version) -> Version {
+pub fn bump_version(level: &BumpLevel, current: &Version) -> Result<Version> {
     let mut new_version = current.clone();
     match level {
         BumpLevel::Major => {
@@ -167,7 +167,7 @@ pub fn bump_version(level: &BumpLevel, current: &Version) -> Version {
         }
     }
 
-    new_version
+    Ok(new_version)
 }
 
 #[cfg(test)]
@@ -177,29 +177,29 @@ mod tests {
     #[test]
     fn test_bump_version_major() {
         assert_eq!(
-            bump_version(&BumpLevel::Major, &Version::parse("1.0.0").unwrap()),
+            bump_version(&BumpLevel::Major, &Version::parse("1.0.0").unwrap()).unwrap(),
             Version::parse("2.0.0").unwrap()
         );
 
         assert_eq!(
-            bump_version(&BumpLevel::Major, &Version::parse("1.1.0").unwrap()),
+            bump_version(&BumpLevel::Major, &Version::parse("1.1.0").unwrap()).unwrap(),
             Version::parse("2.0.0").unwrap()
         );
 
         assert_eq!(
-            bump_version(&BumpLevel::Major, &Version::parse("1.1.1").unwrap()),
+            bump_version(&BumpLevel::Major, &Version::parse("1.1.1").unwrap()).unwrap(),
             Version::parse("2.0.0").unwrap()
         );
     }
     #[test]
     fn test_bump_version_minor() {
         assert_eq!(
-            bump_version(&BumpLevel::Minor, &Version::parse("1.0.0").unwrap()),
+            bump_version(&BumpLevel::Minor, &Version::parse("1.0.0").unwrap()).unwrap(),
             Version::parse("1.1.0").unwrap()
         );
 
         assert_eq!(
-            bump_version(&BumpLevel::Minor, &Version::parse("1.2.1").unwrap()),
+            bump_version(&BumpLevel::Minor, &Version::parse("1.2.1").unwrap()).unwrap(),
             Version::parse("1.3.0").unwrap()
         );
     }
@@ -207,7 +207,7 @@ mod tests {
     #[test]
     fn test_bump_version_patch() {
         assert_eq!(
-            bump_version(&BumpLevel::Patch, &Version::parse("1.0.0").unwrap()),
+            bump_version(&BumpLevel::Patch, &Version::parse("1.0.0").unwrap()).unwrap(),
             Version::parse("1.0.1").unwrap()
         );
     }
@@ -218,28 +218,32 @@ mod tests {
             bump_version(
                 &BumpLevel::PreRelease,
                 &Version::parse("1.2.3-alpha.0").unwrap()
-            ),
+            )
+            .unwrap(),
             Version::parse("1.2.3-alpha.1").unwrap()
         );
         assert_eq!(
             bump_version(
                 &BumpLevel::PreRelease,
                 &Version::parse("1.2.3-alpha.1").unwrap()
-            ),
+            )
+            .unwrap(),
             Version::parse("1.2.3-alpha.2").unwrap()
         );
         assert_eq!(
             bump_version(
                 &BumpLevel::PreRelease,
                 &Version::parse("1.2.3-beta.0").unwrap()
-            ),
+            )
+            .unwrap(),
             Version::parse("1.2.3-beta.1").unwrap()
         );
         assert_eq!(
             bump_version(
                 &BumpLevel::PreRelease,
                 &Version::parse("1.2.3-rc.0").unwrap()
-            ),
+            )
+            .unwrap(),
             Version::parse("1.2.3-rc.1").unwrap()
         );
     }

--- a/src/commands/bump_version.rs
+++ b/src/commands/bump_version.rs
@@ -190,9 +190,11 @@ pub fn bump_version(level: &BumpLevel, current: &Version) -> Result<Version> {
                         new_version.pre = semver::Prerelease::new("").unwrap();
                     }
                     _ => {
-                        return Err(anyhow!("unexpected prerelease prefix: {prefix}"));
+                        return Err(anyhow!("unexpected prerelease format: {}, only alpha, beta, and rc are supported", current.pre));
                     }
                 }
+            } else {
+                return Err(anyhow!("unexpected prerelease format: {}", current.pre));
             }
         }
         BumpLevel::PatchOrPreRelease => {
@@ -285,16 +287,22 @@ mod tests {
         );
 
         assert_eq!(
-            bump_version(&BumpLevel::PreRelease, &Version::parse("1.2.3-alpha123").unwrap())
-                .unwrap_err()
-                .to_string(),
+            bump_version(
+                &BumpLevel::PreRelease,
+                &Version::parse("1.2.3-alpha123").unwrap()
+            )
+            .unwrap_err()
+            .to_string(),
             "unexpected prerelease format: alpha123",
         );
 
         assert_eq!(
-            bump_version(&BumpLevel::PreRelease, &Version::parse("1.2.3-alpha.custom").unwrap())
-                .unwrap_err()
-                .to_string(),
+            bump_version(
+                &BumpLevel::PreRelease,
+                &Version::parse("1.2.3-alpha.custom").unwrap()
+            )
+            .unwrap_err()
+            .to_string(),
             "unexpected prerelease format: alpha.custom",
         );
     }
@@ -335,6 +343,26 @@ mod tests {
             )
             .unwrap(),
             Version::parse("1.2.3").unwrap()
+        );
+
+        assert_eq!(
+            bump_version(
+                &BumpLevel::PromotePreRelease,
+                &Version::parse("1.2.3-alpha123").unwrap()
+            )
+            .unwrap_err()
+            .to_string(),
+            "unexpected prerelease format: alpha123",
+        );
+
+        assert_eq!(
+            bump_version(
+                &BumpLevel::PromotePreRelease,
+                &Version::parse("1.2.3-custom.1").unwrap()
+            )
+            .unwrap_err()
+            .to_string(),
+            "unexpected prerelease format: custom.1, only alpha, beta, and rc are supported"
         );
     }
 

--- a/src/commands/bump_version.rs
+++ b/src/commands/bump_version.rs
@@ -192,10 +192,10 @@ pub fn bump_version(level: &BumpLevel, current: &Version) -> Result<Version> {
             }
         }
         BumpLevel::PatchOrPreRelease => {
-            if !current.pre.is_empty() {
-                new_version = bump_version(&BumpLevel::PreRelease, current)?;
-            } else {
+            if current.pre.is_empty() {
                 new_version = bump_version(&BumpLevel::Patch, current)?;
+            } else {
+                new_version = bump_version(&BumpLevel::PreRelease, current)?;
             }
         }
     }

--- a/src/commands/bump_version.rs
+++ b/src/commands/bump_version.rs
@@ -15,9 +15,13 @@ pub struct CommandArgs {
 
 #[derive(ValueEnum, Clone, Debug)]
 pub enum BumpLevel {
+    #[value(help = "Bump major: x.y.z -> x+1.0.0")]
     Major,
+    #[value(help = "Bump minor: x.y.z -> x.y+1.0")]
     Minor,
+    #[value(help = "Bump patch: x.y.z -> x.y.z+1")]
     Patch,
+    #[value(help = "Bump prerelease suffix: x.y.z-<tag>.n -> x.y.z-<tag>.n+1 (e.g. alpha/beta/rc)")]
     PreRelease,
 }
 

--- a/src/commands/bump_version.rs
+++ b/src/commands/bump_version.rs
@@ -21,7 +21,9 @@ pub enum BumpLevel {
     Minor,
     #[value(help = "Bump patch: x.y.z -> x.y.z+1")]
     Patch,
-    #[value(help = "Bump prerelease suffix: x.y.z-<tag>.n -> x.y.z-<tag>.n+1 (e.g. alpha/beta/rc)")]
+    #[value(
+        help = "Bump prerelease suffix: x.y.z-<tag>.n -> x.y.z-<tag>.n+1 (e.g. alpha/beta/rc)"
+    )]
     PreRelease,
 }
 
@@ -173,69 +175,72 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_bump_version() {
-        // bump major
-        {
-            assert_eq!(
-                bump_version(&BumpLevel::Major, &Version::parse("1.0.0").unwrap()),
-                Version::parse("2.0.0").unwrap()
-            );
+    fn test_bump_version_major() {
+        assert_eq!(
+            bump_version(&BumpLevel::Major, &Version::parse("1.0.0").unwrap()),
+            Version::parse("2.0.0").unwrap()
+        );
 
-            assert_eq!(
-                bump_version(&BumpLevel::Major, &Version::parse("1.1.0").unwrap()),
-                Version::parse("2.0.0").unwrap()
-            );
+        assert_eq!(
+            bump_version(&BumpLevel::Major, &Version::parse("1.1.0").unwrap()),
+            Version::parse("2.0.0").unwrap()
+        );
 
-            assert_eq!(
-                bump_version(&BumpLevel::Major, &Version::parse("1.1.1").unwrap()),
-                Version::parse("2.0.0").unwrap()
-            );
-        }
+        assert_eq!(
+            bump_version(&BumpLevel::Major, &Version::parse("1.1.1").unwrap()),
+            Version::parse("2.0.0").unwrap()
+        );
+    }
+    #[test]
+    fn test_bump_version_minor() {
+        assert_eq!(
+            bump_version(&BumpLevel::Minor, &Version::parse("1.0.0").unwrap()),
+            Version::parse("1.1.0").unwrap()
+        );
 
-        // bump minor
-        {
-            assert_eq!(
-                bump_version(&BumpLevel::Minor, &Version::parse("1.0.0").unwrap()),
-                Version::parse("1.1.0").unwrap()
-            );
+        assert_eq!(
+            bump_version(&BumpLevel::Minor, &Version::parse("1.2.1").unwrap()),
+            Version::parse("1.3.0").unwrap()
+        );
+    }
 
-            assert_eq!(
-                bump_version(&BumpLevel::Minor, &Version::parse("1.2.1").unwrap()),
-                Version::parse("1.3.0").unwrap()
-            );
-        }
+    #[test]
+    fn test_bump_version_patch() {
+        assert_eq!(
+            bump_version(&BumpLevel::Patch, &Version::parse("1.0.0").unwrap()),
+            Version::parse("1.0.1").unwrap()
+        );
+    }
 
-        // bump patch
-        {
-            assert_eq!(
-                bump_version(&BumpLevel::Patch, &Version::parse("1.0.0").unwrap()),
-                Version::parse("1.0.1").unwrap()
-            );
-        }
-
-        // bump pre-release
-        {
-            assert_eq!(
-                bump_version(
-                    &BumpLevel::PreRelease,
-                    &Version::parse("1.2.3-alpha.0").unwrap()
-                ),
-                Version::parse("1.2.3-alpha.1").unwrap()
-            );
-            assert_eq!(
-                bump_version(
-                    &BumpLevel::PreRelease,
-                    &Version::parse("1.2.3-beta.0").unwrap()
-                ),
-                Version::parse("1.2.3-beta.1").unwrap()
-            );
-            assert_eq!(
-                bump_version(
-                    &BumpLevel::PreRelease,
-                    &Version::parse("1.2.3-rc.0").unwrap()
-                ),
-                Version::parse("1.2.3-rc.1").unwrap()
-            );
-        }
+    #[test]
+    fn test_bump_version_prerelease() {
+        assert_eq!(
+            bump_version(
+                &BumpLevel::PreRelease,
+                &Version::parse("1.2.3-alpha.0").unwrap()
+            ),
+            Version::parse("1.2.3-alpha.1").unwrap()
+        );
+        assert_eq!(
+            bump_version(
+                &BumpLevel::PreRelease,
+                &Version::parse("1.2.3-alpha.1").unwrap()
+            ),
+            Version::parse("1.2.3-alpha.2").unwrap()
+        );
+        assert_eq!(
+            bump_version(
+                &BumpLevel::PreRelease,
+                &Version::parse("1.2.3-beta.0").unwrap()
+            ),
+            Version::parse("1.2.3-beta.1").unwrap()
+        );
+        assert_eq!(
+            bump_version(
+                &BumpLevel::PreRelease,
+                &Version::parse("1.2.3-rc.0").unwrap()
+            ),
+            Version::parse("1.2.3-rc.1").unwrap()
+        );
     }
 }


### PR DESCRIPTION
#### Problem

we want to adapt `bump-version` command to agave, but it's missing some handy options.

#### Summary of Changes

- introduce more options to `bump-version`
  - pre-release
  - promote-pre-release
  - patch-or-pre-release
- improve --help


```
$ cargo run -- bump-version --help
Bump version

Usage: xtask bump-version [OPTIONS] <LEVEL>

Arguments:
  <LEVEL>
          Possible values:
          - major:                Bump major: x.y.z -> x+1.0.0
          - minor:                Bump minor: x.y.z -> x.y+1.0
          - patch:                Bump patch: x.y.z -> x.y.z+1
          - pre-release:          Bump prerelease suffix: x.y.z-<tag>.n -> x.y.z-<tag>.n+1 (e.g. alpha/beta/rc)
          - promote-pre-release:  Promote prerelease stage: alpha.n -> beta.0, beta.n -> rc.0, rc.n -> '' (removed rc prerelease)
          - patch-or-pre-release: Bump prerelease if present; otherwise bump patch (x.y.z-<tag>.n -> x.y.z-<tag>.n+1, x.y.z -> x.y.z+1)

Options:
  -v, --verbose
          Enable verbose (debug) logging

  -h, --help
          Print help (see a summary with '-h')
```