### PR TITLE
Enable oidc authentication on codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           files: target/coverage/lcov.info
+          use_oidc: true
 
       - name: Generate HTML report
         if: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
token-less uploads are not allowed for protected branches and oidc is disabled by default: https://github.com/anza-xyz/xtask/actions/runs/21910820785/job/63263908846