### PR TITLE
ci: create profraw directory before running coverage tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,9 @@ jobs:
         env:
           RUSTFLAGS: "-C instrument-coverage"
           LLVM_PROFILE_FILE: "target/coverage/profraw/xtask-%p-%m.profraw"
-        run: cargo test --all-features
+        run: |
+          mkdir -p target/coverage/profraw
+          cargo test --all-features
 
       - name: Generate lcov report
         run: |


### PR DESCRIPTION
LLVM silently drops profraw output if the directory doesn't exist. The first test binary to run loses its coverage and later processes succeed by luck. Found this when unit test coverage was lower than the no-tests baseline.