### PR TITLE
Give CI permissions required for OIDC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  # Required for OIDC: https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-cloud-providers#adding-permissions-settings
+  id-token: write
+
 jobs:
   test:
     name: Test


### PR DESCRIPTION
`id-token: write` is required for OIDC to work. It does not give any actual write permissions: https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-cloud-providers#adding-permissions-settings

Workflow fail without it: https://github.com/anza-xyz/xtask/actions/runs/21912436671/job/63269983682