### PR TITLE
ci: grant id-token write permission to coverage job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,8 @@ jobs:
   coverage:
     name: Code Coverage
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Required for OIDC token exchange with codecov. Without `id-token: write`, GitHub does not inject `ACTIONS_ID_TOKEN_REQUEST_URL` into the runner environment and the upload fails with `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable`.

Failing job: https://github.com/anza-xyz/xtask/actions/runs/21912436671/job/63269983682