### PR TITLE
ci: install cargo-llvm-cov via cargo install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,13 +62,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: llvm-tools-preview
+      - name: Install llvm-tools
+        run: rustup component add llvm-tools-preview
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+        run: cargo install cargo-llvm-cov --locked
 
       - name: Run tests with coverage
         run: cargo llvm-cov --all-features --lcov --output-path target/lcov.info


### PR DESCRIPTION
`taiki-e/install-action` requires apt to install dependencies which fails when running as a non-root user. Replacing it with `cargo install` fixes this. Also replaces `dtolnay/rust-toolchain` with `rustup component add` for consistency.