### PR TITLE
refactor: move CLI to src/bin/xtask.rs

### DIFF
--- a/src/bin/xtask.rs
+++ b/src/bin/xtask.rs
@@ -4,9 +4,6 @@ use {
     log::error,
 };
 
-mod commands;
-mod utils;
-
 #[derive(Parser)]
 #[command(name = "xtask", about = "Build tasks", version)]
 struct Xtask {
@@ -22,16 +19,15 @@ enum Commands {
     #[command(about = "Hello")]
     Hello,
     #[command(about = "Bump version")]
-    BumpVersion(commands::bump_version::CommandArgs),
+    BumpVersion(xtask::commands::bump_version::CommandArgs),
     #[command(about = "Update crate version")]
-    UpdateCrate(commands::update_crate::CommandArgs),
+    UpdateCrate(xtask::commands::update_crate::CommandArgs),
     #[command(about = "Publish crates")]
-    Publish(commands::publish::CommandArgs),
+    Publish(xtask::commands::publish::CommandArgs),
 }
 
 #[derive(Args, Debug)]
 pub struct GlobalOptions {
-    /// Enable verbose (debug) logging
     #[arg(short, long, global = true)]
     pub verbose: bool,
 }
@@ -48,10 +44,8 @@ async fn main() {
 }
 
 async fn try_main() -> Result<()> {
-    // parse the command line arguments
     let xtask = Xtask::parse();
 
-    // set the log level
     if xtask.global.verbose {
         std::env::set_var("RUST_LOG", "debug");
     } else {
@@ -59,17 +53,16 @@ async fn try_main() -> Result<()> {
     }
     env_logger::init();
 
-    // run the command
     match xtask.command {
-        Commands::Hello => commands::hello::run()?,
+        Commands::Hello => xtask::commands::hello::run()?,
         Commands::BumpVersion(args) => {
-            commands::bump_version::run(args)?;
+            xtask::commands::bump_version::run(args)?;
         }
         Commands::UpdateCrate(args) => {
-            commands::update_crate::run(args)?;
+            xtask::commands::update_crate::run(args)?;
         }
         Commands::Publish(args) => {
-            commands::publish::run(args)?;
+            xtask::commands::publish::run(args)?;
         }
     }
 

--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -5,7 +5,6 @@ use {
     clap::{Args, Subcommand},
     log::info,
     scopeguard::defer,
-    serde::Serialize,
     std::{
         collections::{HashMap, HashSet},
         fs,
@@ -16,6 +15,19 @@ use {
     },
     toml_edit::{value, DocumentMut},
 };
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct PackageInfo {
+    pub name: String,
+    pub path: std::path::PathBuf,
+    pub dependencies: HashSet<PackageId>,
+}
+
+pub struct PublishOrderData {
+    pub levels: Vec<Vec<PackageId>>,
+    pub id_to_level: std::collections::HashMap<PackageId, usize>,
+    pub id_to_package_info: HashMap<PackageId, PackageInfo>,
+}
 
 #[derive(Debug, Clone, clap::ValueEnum)]
 pub enum OutputFormat {
@@ -54,20 +66,6 @@ pub fn run(args: CommandArgs) -> Result<()> {
         }
     }
     Ok(())
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct PackageInfo {
-    pub name: String,
-    pub path: PathBuf,
-    pub dependencies: HashSet<PackageId>,
-}
-
-#[derive(Debug)]
-pub struct PublishOrderData {
-    pub levels: Vec<Vec<PackageId>>,
-    pub id_to_level: HashMap<PackageId, usize>,
-    pub id_to_package_info: HashMap<PackageId, PackageInfo>,
 }
 
 pub fn compute_publish_order_data(manifest_path: &str) -> Result<PublishOrderData> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,10 +32,7 @@
 pub mod commands;
 pub mod utils;
 
-pub use commands::bump_version;
-pub use commands::publish;
-pub use commands::update_crate;
-
+pub use commands::{bump_version, publish, update_crate};
 pub use semver::Version;
 
 pub type Result<T> = anyhow::Result<T>;


### PR DESCRIPTION
#### Summary

- Renames \`src/main.rs\` to \`src/bin/xtask.rs\` to follow the Rust convention for crates that expose both a library and a binary

> Part 2 of 2 — merge after #17