### PR TITLE
add env to buildkite's command step

### DIFF
--- a/src/buildkite/command_step.rs
+++ b/src/buildkite/command_step.rs
@@ -25,6 +25,9 @@ pub struct CommandStep {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retry: Option<HashMap<String, String>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub env: Option<HashMap<String, String>>,
 }
 
 #[cfg(test)]
@@ -61,6 +64,10 @@ mod tests {
                     String::from("automatic"),
                     String::from("true"),
                 )])),
+                env: Some(HashMap::from([(
+                    String::from("FETCH_COVERAGE_ENV"),
+                    String::from("true"),
+                )])),
                 ..Default::default()
             },
             r#"{
@@ -70,7 +77,8 @@ mod tests {
                 "soft_fail": false,
                 "agents": {"queue": "test"},
                 "timeout_in_minutes": 15,
-                "retry": {"automatic": "true"}
+                "retry": {"automatic": "true"},
+                "env": {"FETCH_COVERAGE_ENV": "true"}
             }"#,
         );
     }


### PR DESCRIPTION
#### Problem

I added environment variables to the coverage steps:
https://github.com/anza-xyz/agave/blob/95542233cd95309fab114fe9dcbbbd63a06e5390/ci/buildkite-pipeline.sh#L299-L300

#### Summary of Changes

support passing env in command steps