### PR TITLE
add --rm to publish test docker command

### DIFF
--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -307,6 +307,7 @@ fn start_docker_registry() -> Result<String> {
     let output = Command::new("docker")
         .args([
             "run",
+            "--rm",
             "-d",
             "--name",
             "kellnr",


### PR DESCRIPTION
forgot the `--rm` arg 🫠  https://buildkite.com/anza/agave/builds/44521#019d1b4c-fc69-4d04-b422-8e2641efd9be/L149

<img width="1485" height="113" alt="Screenshot 2026-03-24 at 00 23 06" src="https://github.com/user-attachments/assets/15d2657b-ae70-45fb-b81b-a17852246951" />
