### PR TITLE
extend update-crate command to update creates in dev-dependencies

### DIFF
--- a/src/commands/update_crate.rs
+++ b/src/commands/update_crate.rs
@@ -65,6 +65,17 @@ pub fn run(args: CommandArgs) -> Result<()> {
             }
         }
 
+        if let Some(dev_deps) = doc
+            .get_mut("dev-dependencies")
+            .and_then(|deps| deps.as_table_mut())
+            .and_then(|deps| deps.get_mut(&args.package))
+        {
+            if update_dependency_spec(dev_deps, &args.from, &args.to) {
+                need_to_write = true;
+                info!("  ✅ updated dev-dependencies");
+            }
+        }
+
         if need_to_write {
             fs::write(&cargo_toml, doc.to_string())?;
         } else {

--- a/src/commands/update_crate.rs
+++ b/src/commands/update_crate.rs
@@ -23,6 +23,11 @@ pub struct CommandArgs {
 
 pub fn run(args: CommandArgs) -> Result<()> {
     let all_cargo_tomls = utils::recursive_find_files(&args.root_path, "Cargo.toml", |_| true)?;
+    let dependency_targets: &[(&[&str], &str)] = &[
+        (&["workspace", "dependencies"], "workspace.dependencies"),
+        (&["dependencies"], "dependencies"),
+        (&["dev-dependencies"], "dev-dependencies"),
+    ];
 
     'MAIN_LOOP: for cargo_toml in all_cargo_tomls {
         info!("[{}]", cargo_toml.display());
@@ -41,38 +46,10 @@ pub fn run(args: CommandArgs) -> Result<()> {
         let mut doc = content.parse::<DocumentMut>()?;
         let mut need_to_write = false;
 
-        if let Some(workspace_deps) = doc
-            .get_mut("workspace")
-            .and_then(|ws| ws.as_table_mut())
-            .and_then(|ws| ws.get_mut("dependencies"))
-            .and_then(|deps| deps.as_table_mut())
-            .and_then(|deps| deps.get_mut(&args.package))
-        {
-            if update_dependency_spec(workspace_deps, &args.from, &args.to) {
+        for (path, label) in dependency_targets {
+            if update_dependency_at(&mut doc, path, &args.package, &args.from, &args.to) {
                 need_to_write = true;
-                info!("  ✅ updated workspace.dependencies");
-            }
-        }
-
-        if let Some(deps) = doc
-            .get_mut("dependencies")
-            .and_then(|deps| deps.as_table_mut())
-            .and_then(|deps| deps.get_mut(&args.package))
-        {
-            if update_dependency_spec(deps, &args.from, &args.to) {
-                need_to_write = true;
-                info!("  ✅ updated dependencies");
-            }
-        }
-
-        if let Some(dev_deps) = doc
-            .get_mut("dev-dependencies")
-            .and_then(|deps| deps.as_table_mut())
-            .and_then(|deps| deps.get_mut(&args.package))
-        {
-            if update_dependency_spec(dev_deps, &args.from, &args.to) {
-                need_to_write = true;
-                info!("  ✅ updated dev-dependencies");
+                info!("  ✅ updated {label}");
             }
         }
 
@@ -83,6 +60,27 @@ pub fn run(args: CommandArgs) -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn update_dependency_at(
+    doc: &mut DocumentMut,
+    path: &[&str],
+    package: &str,
+    from: &str,
+    to: &str,
+) -> bool {
+    let mut table = doc.as_table_mut();
+
+    for key in path {
+        let Some(next_table) = table.get_mut(key).and_then(Item::as_table_mut) else {
+            return false;
+        };
+        table = next_table;
+    }
+
+    table
+        .get_mut(package)
+        .is_some_and(|dep_spec| update_dependency_spec(dep_spec, from, to))
 }
 
 fn update_dependency_spec(dep_spec: &mut Item, from: &str, to: &str) -> bool {

--- a/tests/dummy-workspace-crates-update/a/Cargo.toml
+++ b/tests/dummy-workspace-crates-update/a/Cargo.toml
@@ -5,3 +5,6 @@ edition = { workspace = true }
 
 [dependencies]
 solana-frozen-abi = { workspace = true }
+
+[dev-dependencies]
+solana-frozen-abi = { workspace = true }

--- a/tests/dummy-workspace-crates-update/b/Cargo.toml
+++ b/tests/dummy-workspace-crates-update/b/Cargo.toml
@@ -5,3 +5,6 @@ edition = { workspace = true }
 
 [dependencies]
 solana-frozen-abi = "3.0.0"
+
+[dev-dependencies]
+solana-frozen-abi = "3.0.0"

--- a/tests/update_crate.rs
+++ b/tests/update_crate.rs
@@ -51,9 +51,12 @@ fn test_update_crate() {
 
     // verify a/Cargo.toml
     let a_cargo_toml_content = fs::read_to_string(root_path.join("a/Cargo.toml")).unwrap();
-    assert!(
-        a_cargo_toml_content.contains(r#"solana-frozen-abi = { workspace = true }"#),
-        "a/Cargo.toml should not change"
+    assert_eq!(
+        a_cargo_toml_content
+            .matches(r#"solana-frozen-abi = { workspace = true }"#)
+            .count(),
+        2,
+        "workspace-inherited dependencies in a/Cargo.toml should not change"
     );
 
     // verify b/Cargo.toml
@@ -61,6 +64,10 @@ fn test_update_crate() {
     assert!(
         b_cargo_toml_content.contains(r#"solana-frozen-abi = "3.1.0""#),
         "b/Cargo.toml should be updated to 3.1.0"
+    );
+    assert!(
+        b_cargo_toml_content.contains("[dev-dependencies]\nsolana-frozen-abi = \"3.1.0\""),
+        "dev-dependencies in b/Cargo.toml should be updated to 3.1.0"
     );
 
     // verify c/Cargo.toml


### PR DESCRIPTION
#### Problem

some crates may exist only in `dev-dependencies`, and there is harmless to extend the command to update it.

#### Summary of Changes

extend update-crate command to update creates in dev-dependencies