### PR TITLE
feat: verify bump-version only edits version fields

### DIFF
--- a/src/commands/bump_version.rs
+++ b/src/commands/bump_version.rs
@@ -255,38 +255,37 @@ fn verify_lock_changes(
     let current = current.to_string();
     let new = new.to_string();
 
-    // The only allowed change: workspace crates locked at the old version move to
-    // the new version. Anything else (e.g. a transitive dep whose version jumps
-    // because of a flexible range) is an unexpected change.
-    let mut expected_removed: BTreeSet<(String, String)> = BTreeSet::new();
-    let mut expected_added: BTreeSet<(String, String)> = BTreeSet::new();
-    for (name, version) in &before_pkgs {
-        if crates.contains(name.as_str()) && version == &current {
-            expected_removed.insert((name.clone(), current.clone()));
-            expected_added.insert((name.clone(), new.clone()));
-        }
+    // Rebuild the lock we expect: workspace crates move current -> new, every
+    // other package (source, checksum, dependency edges) stays identical.
+    let mut expected: BTreeMap<(String, String), String> = BTreeMap::new();
+    for ((name, version), body) in &before_pkgs {
+        let key = if crates.contains(name.as_str()) && version == &current {
+            (name.clone(), new.clone())
+        } else {
+            (name.clone(), version.clone())
+        };
+        expected.insert(key, body.clone());
     }
 
-    let actual_removed: BTreeSet<(String, String)> =
-        before_pkgs.difference(&after_pkgs).cloned().collect();
-    let actual_added: BTreeSet<(String, String)> =
-        after_pkgs.difference(&before_pkgs).cloned().collect();
-
-    if actual_removed == expected_removed && actual_added == expected_added {
+    if expected == after_pkgs {
         return Ok(());
     }
 
     let mut errors = vec![];
-    for (name, version) in actual_added.difference(&expected_added) {
-        errors.push(format!("  unexpected package `{name} {version}`"));
-    }
-    for (name, version) in actual_removed.difference(&expected_removed) {
-        errors.push(format!("  unexpectedly removed package `{name} {version}`"));
-    }
-    for (name, version) in expected_added.difference(&actual_added) {
-        errors.push(format!(
-            "  expected `{name}` to be bumped to `{version}` but it was not"
-        ));
+    let keys: BTreeSet<&(String, String)> = expected.keys().chain(after_pkgs.keys()).collect();
+    for key @ (name, version) in keys {
+        match (expected.get(key), after_pkgs.get(key)) {
+            (Some(want), Some(got)) if want != got => {
+                errors.push(format!("  unexpected change to package `{name} {version}`"));
+            }
+            (Some(_), None) => {
+                errors.push(format!("  missing package `{name} {version}` after bump"));
+            }
+            (None, Some(_)) => {
+                errors.push(format!("  unexpected package `{name} {version}`"));
+            }
+            _ => {}
+        }
     }
 
     Err(anyhow!(
@@ -296,17 +295,28 @@ fn verify_lock_changes(
     ))
 }
 
-fn parse_lock_packages(content: &str) -> Result<BTreeSet<(String, String)>> {
+fn parse_lock_packages(content: &str) -> Result<BTreeMap<(String, String), String>> {
     let doc = content.parse::<DocumentMut>()?;
 
-    let mut packages = BTreeSet::new();
+    let mut packages = BTreeMap::new();
     if let Some(Item::ArrayOfTables(entries)) = doc.get("package") {
         for entry in entries.iter() {
             let name = entry.get("name").and_then(Item::as_str);
             let version = entry.get("version").and_then(Item::as_str);
-            if let (Some(name), Some(version)) = (name, version) {
-                packages.insert((name.to_string(), version.to_string()));
+            let (Some(name), Some(version)) = (name, version) else {
+                continue;
+            };
+
+            let mut fields = vec![];
+            for (key, item) in entry.iter() {
+                if key == "name" || key == "version" {
+                    continue;
+                }
+                fields.push(format!("{key}={}", item.to_string().trim()));
             }
+            fields.sort();
+
+            packages.insert((name.to_string(), version.to_string()), fields.join("\n"));
         }
     }
 
@@ -719,7 +729,7 @@ mod tests {
         .to_string();
         assert!(err.contains("unexpected package `serde 1.0.200`"), "{err}");
         assert!(
-            err.contains("unexpectedly removed package `serde 1.0.150`"),
+            err.contains("missing package `serde 1.0.150` after bump"),
             "{err}"
         );
     }
@@ -756,7 +766,28 @@ mod tests {
         .unwrap_err()
         .to_string();
         assert!(
-            err.contains("expected `foo` to be bumped to `1.1.0` but it was not"),
+            err.contains("missing package `foo 1.1.0` after bump"),
+            "{err}"
+        );
+        assert!(err.contains("unexpected package `foo 1.0.0`"), "{err}");
+    }
+
+    #[test]
+    fn test_verify_lock_changes_detects_moved_dependency_edge() {
+        let before = "version = 3\n\n[[package]]\nname = \"foo\"\nversion = \"1.0.0\"\n\n[[package]]\nname = \"tokio\"\nversion = \"1.52.3\"\ndependencies = [\"windows-sys 0.61.0\"]\n\n[[package]]\nname = \"windows-sys\"\nversion = \"0.45.0\"\n\n[[package]]\nname = \"windows-sys\"\nversion = \"0.61.0\"\n";
+        let after = "version = 3\n\n[[package]]\nname = \"foo\"\nversion = \"1.1.0\"\n\n[[package]]\nname = \"tokio\"\nversion = \"1.52.3\"\ndependencies = [\"windows-sys 0.45.0\"]\n\n[[package]]\nname = \"windows-sys\"\nversion = \"0.45.0\"\n\n[[package]]\nname = \"windows-sys\"\nversion = \"0.61.0\"\n";
+        let err = verify_lock_changes(
+            before,
+            after,
+            &crates(&["foo"]),
+            &Version::parse("1.0.0").unwrap(),
+            &Version::parse("1.1.0").unwrap(),
+            Path::new("Cargo.lock"),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(
+            err.contains("unexpected change to package `tokio 1.52.3`"),
             "{err}"
         );
     }

--- a/src/commands/bump_version.rs
+++ b/src/commands/bump_version.rs
@@ -150,6 +150,9 @@ pub fn run(args: CommandArgs) -> Result<()> {
             cargo_lock.display()
         ))?;
 
+        let before = fs::read_to_string(&cargo_lock)
+            .context(format!("failed to read {}", cargo_lock.display()))?;
+
         info!("running `cargo tree` in {}", dir.display());
         let output = Command::new("cargo")
             .arg("tree")
@@ -159,6 +162,22 @@ pub fn run(args: CommandArgs) -> Result<()> {
         if !output.status.success() {
             return Err(anyhow!("{}", String::from_utf8_lossy(&output.stderr)));
         }
+
+        let after = fs::read_to_string(&cargo_lock)
+            .context(format!("failed to read {}", cargo_lock.display()))?;
+
+        verify_lock_changes(
+            &before,
+            &after,
+            &all_crates,
+            &current_version,
+            &new_version,
+            &cargo_lock,
+        )
+        .context(format!(
+            "unexpected changes while bumping {}",
+            cargo_lock.display()
+        ))?;
     }
 
     Ok(())
@@ -217,6 +236,81 @@ fn verify_changes(
         file.display(),
         errors.join("\n")
     ))
+}
+
+fn verify_lock_changes(
+    before: &str,
+    after: &str,
+    all_crates: &[String],
+    current: &Version,
+    new: &Version,
+    file: &Path,
+) -> Result<()> {
+    let before_pkgs = parse_lock_packages(before)
+        .context(format!("failed to parse {} before bump", file.display()))?;
+    let after_pkgs = parse_lock_packages(after)
+        .context(format!("failed to parse {} after bump", file.display()))?;
+
+    let crates: BTreeSet<&str> = all_crates.iter().map(String::as_str).collect();
+    let current = current.to_string();
+    let new = new.to_string();
+
+    // The only allowed change: workspace crates locked at the old version move to
+    // the new version. Anything else (e.g. a transitive dep whose version jumps
+    // because of a flexible range) is an unexpected change.
+    let mut expected_removed: BTreeSet<(String, String)> = BTreeSet::new();
+    let mut expected_added: BTreeSet<(String, String)> = BTreeSet::new();
+    for (name, version) in &before_pkgs {
+        if crates.contains(name.as_str()) && version == &current {
+            expected_removed.insert((name.clone(), current.clone()));
+            expected_added.insert((name.clone(), new.clone()));
+        }
+    }
+
+    let actual_removed: BTreeSet<(String, String)> =
+        before_pkgs.difference(&after_pkgs).cloned().collect();
+    let actual_added: BTreeSet<(String, String)> =
+        after_pkgs.difference(&before_pkgs).cloned().collect();
+
+    if actual_removed == expected_removed && actual_added == expected_added {
+        return Ok(());
+    }
+
+    let mut errors = vec![];
+    for (name, version) in actual_added.difference(&expected_added) {
+        errors.push(format!("  unexpected package `{name} {version}`"));
+    }
+    for (name, version) in actual_removed.difference(&expected_removed) {
+        errors.push(format!("  unexpectedly removed package `{name} {version}`"));
+    }
+    for (name, version) in expected_added.difference(&actual_added) {
+        errors.push(format!(
+            "  expected `{name}` to be bumped to `{version}` but it was not"
+        ));
+    }
+
+    Err(anyhow!(
+        "version bump touched unexpected content in {}:\n{}",
+        file.display(),
+        errors.join("\n")
+    ))
+}
+
+fn parse_lock_packages(content: &str) -> Result<BTreeSet<(String, String)>> {
+    let doc = content.parse::<DocumentMut>()?;
+
+    let mut packages = BTreeSet::new();
+    if let Some(Item::ArrayOfTables(entries)) = doc.get("package") {
+        for entry in entries.iter() {
+            let name = entry.get("name").and_then(Item::as_str);
+            let version = entry.get("version").and_then(Item::as_str);
+            if let (Some(name), Some(version)) = (name, version) {
+                packages.insert((name.to_string(), version.to_string()));
+            }
+        }
+    }
+
+    Ok(packages)
 }
 
 fn flatten_leaves(doc: &DocumentMut) -> BTreeMap<String, String> {
@@ -578,5 +672,109 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("wrong change at `package.version`"), "{err}");
+    }
+
+    fn lock(packages: &[(&str, &str)]) -> String {
+        let mut out = String::from("version = 3\n");
+        for (name, version) in packages {
+            out.push_str(&format!(
+                "\n[[package]]\nname = \"{name}\"\nversion = \"{version}\"\n"
+            ));
+        }
+        out
+    }
+
+    fn crates(names: &[&str]) -> Vec<String> {
+        names.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn test_verify_lock_changes_ok() {
+        let before = lock(&[("foo", "1.0.0"), ("serde", "1.0.150")]);
+        let after = lock(&[("foo", "1.1.0"), ("serde", "1.0.150")]);
+        assert!(verify_lock_changes(
+            &before,
+            &after,
+            &crates(&["foo"]),
+            &Version::parse("1.0.0").unwrap(),
+            &Version::parse("1.1.0").unwrap(),
+            Path::new("Cargo.lock"),
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_verify_lock_changes_detects_transitive_jump() {
+        let before = lock(&[("foo", "1.0.0"), ("serde", "1.0.150")]);
+        let after = lock(&[("foo", "1.1.0"), ("serde", "1.0.200")]);
+        let err = verify_lock_changes(
+            &before,
+            &after,
+            &crates(&["foo"]),
+            &Version::parse("1.0.0").unwrap(),
+            &Version::parse("1.1.0").unwrap(),
+            Path::new("Cargo.lock"),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("unexpected package `serde 1.0.200`"), "{err}");
+        assert!(
+            err.contains("unexpectedly removed package `serde 1.0.150`"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn test_verify_lock_changes_detects_new_package() {
+        let before = lock(&[("foo", "1.0.0")]);
+        let after = lock(&[("foo", "1.1.0"), ("newdep", "0.1.0")]);
+        let err = verify_lock_changes(
+            &before,
+            &after,
+            &crates(&["foo"]),
+            &Version::parse("1.0.0").unwrap(),
+            &Version::parse("1.1.0").unwrap(),
+            Path::new("Cargo.lock"),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("unexpected package `newdep 0.1.0`"), "{err}");
+    }
+
+    #[test]
+    fn test_verify_lock_changes_detects_skipped_bump() {
+        let before = lock(&[("foo", "1.0.0")]);
+        let after = before.clone();
+        let err = verify_lock_changes(
+            &before,
+            &after,
+            &crates(&["foo"]),
+            &Version::parse("1.0.0").unwrap(),
+            &Version::parse("1.1.0").unwrap(),
+            Path::new("Cargo.lock"),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(
+            err.contains("expected `foo` to be bumped to `1.1.0` but it was not"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn test_verify_lock_changes_ignores_non_workspace_crate() {
+        // A crate that shares the old version string but isn't a workspace member
+        // must not be touched, and its presence must not be required to change.
+        let before = lock(&[("foo", "1.0.0"), ("other", "1.0.0")]);
+        let after = lock(&[("foo", "1.1.0"), ("other", "1.0.0")]);
+        assert!(verify_lock_changes(
+            &before,
+            &after,
+            &crates(&["foo"]),
+            &Version::parse("1.0.0").unwrap(),
+            &Version::parse("1.1.0").unwrap(),
+            Path::new("Cargo.lock"),
+        )
+        .is_ok());
     }
 }

--- a/src/commands/bump_version.rs
+++ b/src/commands/bump_version.rs
@@ -3,8 +3,13 @@ use {
     clap::{Args, ValueEnum},
     log::{debug, info},
     semver::Version,
-    std::{fs, process::Command},
-    toml_edit::{value, DocumentMut},
+    std::{
+        collections::{BTreeMap, BTreeSet},
+        fs,
+        path::Path,
+        process::Command,
+    },
+    toml_edit::{value, DocumentMut, Item, Table, Value},
 };
 
 #[derive(Args)]
@@ -56,6 +61,9 @@ pub fn run(args: CommandArgs) -> Result<()> {
             .parse::<DocumentMut>()
             .context(format!("failed to parse {}", cargo_toml.display()))?;
 
+        let original = doc.clone();
+        let mut intended: BTreeMap<String, (String, String)> = BTreeMap::new();
+
         if let Some(workspace_package_version_str) = doc
             .get("workspace")
             .and_then(|workspace| workspace.get("package"))
@@ -64,6 +72,10 @@ pub fn run(args: CommandArgs) -> Result<()> {
         {
             if workspace_package_version_str == current_version.to_string() {
                 doc["workspace"]["package"]["version"] = value(new_version.to_string());
+                intended.insert(
+                    "workspace.package.version".to_string(),
+                    (current_version.to_string(), new_version.to_string()),
+                );
                 info!("  bumped workspace.package.version from {current_version} to {new_version}",);
             }
         }
@@ -75,7 +87,11 @@ pub fn run(args: CommandArgs) -> Result<()> {
         {
             if package_version_str == current_version.to_string() {
                 doc["package"]["version"] = value(new_version.to_string());
-                info!("  bumped package.version from {current_version} to {current_version}",);
+                intended.insert(
+                    "package.version".to_string(),
+                    (current_version.to_string(), new_version.to_string()),
+                );
+                info!("  bumped package.version from {current_version} to {new_version}",);
             }
         }
 
@@ -98,17 +114,26 @@ pub fn run(args: CommandArgs) -> Result<()> {
                             continue;
                         }
                         let old_version = version.to_string();
-                        let new_version = old_version
+                        let bumped_version = old_version
                             .replace(&current_version.to_string(), &new_version.to_string());
-                        doc["workspace"]["dependencies"][&name]["version"] = value(&new_version);
+                        doc["workspace"]["dependencies"][&name]["version"] = value(&bumped_version);
+                        intended.insert(
+                            format!("workspace.dependencies.{name}.version"),
+                            (old_version.clone(), bumped_version.clone()),
+                        );
                         info!(
                             "  bumped workspace.dependencies.{name}.version from {old_version} to \
-                             {new_version}",
+                             {bumped_version}",
                         );
                     }
                 }
             }
         }
+
+        verify_changes(&original, &doc, &intended, &cargo_toml).context(format!(
+            "unexpected changes while bumping {}",
+            cargo_toml.display()
+        ))?;
 
         // write the updated document back to the file
         debug!("writing {}", cargo_toml.display());
@@ -137,6 +162,116 @@ pub fn run(args: CommandArgs) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn verify_changes(
+    original: &DocumentMut,
+    modified: &DocumentMut,
+    intended: &BTreeMap<String, (String, String)>,
+    file: &Path,
+) -> Result<()> {
+    let before = flatten_leaves(original);
+    let after = flatten_leaves(modified);
+
+    let mut actual: BTreeMap<String, (String, String)> = BTreeMap::new();
+    let paths: BTreeSet<&String> = before.keys().chain(after.keys()).collect();
+    for path in paths {
+        let old = before.get(path);
+        let new = after.get(path);
+        if old != new {
+            actual.insert(
+                path.clone(),
+                (
+                    old.cloned().unwrap_or_default(),
+                    new.cloned().unwrap_or_default(),
+                ),
+            );
+        }
+    }
+
+    if &actual == intended {
+        return Ok(());
+    }
+
+    let mut errors = vec![];
+    for (path, (old, new)) in &actual {
+        match intended.get(path) {
+            None => errors.push(format!(
+                "  unexpected change at `{path}`: {old:?} -> {new:?}"
+            )),
+            Some(expected) if expected != &(old.clone(), new.clone()) => errors.push(format!(
+                "  wrong change at `{path}`: expected {expected:?}, got {:?}",
+                (old, new)
+            )),
+            _ => {}
+        }
+    }
+    for path in intended.keys() {
+        if !actual.contains_key(path) {
+            errors.push(format!("  expected change at `{path}` did not happen"));
+        }
+    }
+
+    Err(anyhow!(
+        "version bump touched unexpected content in {}:\n{}",
+        file.display(),
+        errors.join("\n")
+    ))
+}
+
+fn flatten_leaves(doc: &DocumentMut) -> BTreeMap<String, String> {
+    let mut out = BTreeMap::new();
+    walk_table(doc.as_table(), String::new(), &mut out);
+    out
+}
+
+fn walk_table(table: &Table, prefix: String, out: &mut BTreeMap<String, String>) {
+    for (key, item) in table.iter() {
+        walk_item(item, join(&prefix, key), out);
+    }
+}
+
+fn walk_item(item: &Item, path: String, out: &mut BTreeMap<String, String>) {
+    match item {
+        Item::Value(v) => walk_value(v, path, out),
+        Item::Table(t) => walk_table(t, path, out),
+        Item::ArrayOfTables(arr) => {
+            for (i, t) in arr.iter().enumerate() {
+                walk_table(t, format!("{path}[{i}]"), out);
+            }
+        }
+        Item::None => {}
+    }
+}
+
+fn walk_value(v: &Value, path: String, out: &mut BTreeMap<String, String>) {
+    match v {
+        Value::InlineTable(t) => {
+            for (key, val) in t.iter() {
+                walk_value(val, join(&path, key), out);
+            }
+        }
+        Value::Array(arr) => {
+            for (i, val) in arr.iter().enumerate() {
+                walk_value(val, format!("{path}[{i}]"), out);
+            }
+        }
+        scalar => {
+            let repr = scalar
+                .as_str()
+                .map(str::to_string)
+                .unwrap_or_else(|| scalar.to_string().trim().to_string());
+            out.insert(path, repr);
+        }
+    }
+}
+
+fn join(prefix: &str, key: &str) -> String {
+    if prefix.is_empty() {
+        key.to_string()
+    } else {
+        format!("{prefix}.{key}")
+    }
 }
 
 pub fn bump_version(level: &BumpLevel, current: &Version) -> Result<Version> {
@@ -375,5 +510,73 @@ mod tests {
             .unwrap(),
             Version::parse("1.2.4").unwrap()
         );
+    }
+
+    fn doc(s: &str) -> DocumentMut {
+        s.parse().unwrap()
+    }
+
+    fn intent(pairs: &[(&str, &str, &str)]) -> BTreeMap<String, (String, String)> {
+        pairs
+            .iter()
+            .map(|(p, o, n)| (p.to_string(), (o.to_string(), n.to_string())))
+            .collect()
+    }
+
+    #[test]
+    fn test_verify_changes_ok() {
+        let original = doc("[package]\nname = \"foo\"\nversion = \"1.0.0\"\n");
+        let modified = doc("[package]\nname = \"foo\"\nversion = \"1.1.0\"\n");
+        let intended = intent(&[("package.version", "1.0.0", "1.1.0")]);
+        assert!(verify_changes(&original, &modified, &intended, Path::new("Cargo.toml")).is_ok());
+    }
+
+    #[test]
+    fn test_verify_changes_ignores_formatting() {
+        let original = doc("[package]\nname = \"foo\"\nversion = \"1.0.0\"\n");
+        let modified = doc("[package]\n# comment\nname   =   \"foo\"\nversion = \"1.0.0\"\n");
+        assert!(verify_changes(
+            &original,
+            &modified,
+            &BTreeMap::new(),
+            Path::new("Cargo.toml")
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_verify_changes_detects_stray_edit() {
+        let original = doc("[package]\nname = \"foo\"\nversion = \"1.0.0\"\n");
+        let modified = doc("[package]\nname = \"bar\"\nversion = \"1.1.0\"\n");
+        let intended = intent(&[("package.version", "1.0.0", "1.1.0")]);
+        let err = verify_changes(&original, &modified, &intended, Path::new("Cargo.toml"))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("unexpected change at `package.name`"), "{err}");
+    }
+
+    #[test]
+    fn test_verify_changes_detects_skipped_bump() {
+        let original = doc("[package]\nversion = \"1.0.0\"\n");
+        let modified = original.clone();
+        let intended = intent(&[("package.version", "1.0.0", "1.1.0")]);
+        let err = verify_changes(&original, &modified, &intended, Path::new("Cargo.toml"))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("expected change at `package.version` did not happen"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn test_verify_changes_detects_wrong_value() {
+        let original = doc("[package]\nversion = \"1.0.0\"\n");
+        let modified = doc("[package]\nversion = \"2.0.0\"\n");
+        let intended = intent(&[("package.version", "1.0.0", "1.1.0")]);
+        let err = verify_changes(&original, &modified, &intended, Path::new("Cargo.toml"))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("wrong change at `package.version`"), "{err}");
     }
 }


### PR DESCRIPTION
Guard against stray edits: record each intended bump by key-path, re-diff the original vs edited doc, fail unless changed leaves match exactly. Moves agave's workflow grep guard into the command.

Closes https://github.com/anza-xyz/devops/issues/1976