### PR TITLE
fix: only reset local modifications expected to be done by test_update_crate

### DIFF
--- a/tests/update_crate.rs
+++ b/tests/update_crate.rs
@@ -7,10 +7,6 @@ use {
 #[test]
 #[serial]
 fn test_update_crate() {
-    defer! {
-        Command::new("git").args(["checkout", "."]).output().unwrap();
-    }
-
     let current_file_path_str = file!();
     let root_path = fs::canonicalize(
         Path::new(current_file_path_str)
@@ -19,6 +15,10 @@ fn test_update_crate() {
             .join("dummy-workspace-crates-update"),
     )
     .unwrap();
+
+    defer! {
+        Command::new("git").args(["checkout", &root_path.display().to_string()]).output().unwrap();
+    }
 
     let output = assert_cmd::cargo::cargo_bin_cmd!("cargo-anza-xtask")
         .args([


### PR DESCRIPTION
The current code reset all local modifications on `cargo test` because `test_update_crate` runs `git checkout .` at the end. This makes development to be very unpleasant as it resets all local modifications intentionally made into source files, causing all work done to be lost.

Fix: run `git checkout tests/dummy-workspace` instead